### PR TITLE
プラグインを追加

### DIFF
--- a/.vim/rc/dein.toml
+++ b/.vim/rc/dein.toml
@@ -1,3 +1,11 @@
 [[plugins]]
 repo = 'scrooloose/nerdtree'
 hook_add = 'nnoremap <silent><C-e> :NERDTreeToggle<CR>'
+
+[[plugins]]
+repo = 'tyru/operator-camelize.vim'
+depends = ['vim-operator-user']
+hook_add = 'map <leader>c <plug>(operator-camelize-toggle)'
+
+[[plugins]]
+repo = 'kana/vim-operator-user'


### PR DESCRIPTION
単語を選択して \c でキャメルケースとスネークケースをトグル変換するように設定